### PR TITLE
Handle missing RapidFuzz dependency gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ streamlit run app/app.py
   pip install --no-cache-dir "torch==2.2.2" sentence-transformers==3.0.1
   ```
 
-- **spaCy DE-Modell fehlt (rechte Spalte leer):**  
+- **spaCy DE-Modell fehlt (rechte Spalte leer):**
   ```bash
   python -m spacy download de_core_news_sm
   ```
@@ -82,8 +82,16 @@ streamlit run app/app.py
   pip install https://github.com/explosion/spacy-models/releases/download/de_core_news_sm-3.7.0/de_core_news_sm-3.7.0-py3-none-any.whl
   ```
 
-- **Streamlit React-Fehler (#185) oder Caching-Probleme:**  
-  Browser-Cache leeren / Seite neu laden oder Streamlit neu starten.  
+- **Fuzzy Matching ohne RapidFuzz (Fallback aktiv):**
+  Wenn `rapidfuzz` nicht installiert ist, nutzt die App automatisch einen
+  einfacheren Fuzzy-Vergleich auf Basis der Python-Standardbibliothek. Für
+  präzisere Scores empfiehlt sich die Installation von RapidFuzz:
+  ```bash
+  pip install rapidfuzz
+  ```
+
+- **Streamlit React-Fehler (#185) oder Caching-Probleme:**
+  Browser-Cache leeren / Seite neu laden oder Streamlit neu starten.
   Cache leeren:
   ```bash
   streamlit cache clear


### PR DESCRIPTION
## Summary
- add a standard-library based `rapidfuzz` fallback so the Streamlit app can be imported without optional dependencies
- document the optional RapidFuzz installation path in the README troubleshooting section

## Testing
- pytest
- ruff check app/app.py *(fails: legacy style violations throughout existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b82378f08330a32585e5d86661e4