### PR TITLE
Fix CI timeout and stabilize tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers --disable-warnings --cov=src --cov=presets --cov=evaluation --cov-report=term-missing --cov-report=xml --timeout=30
+addopts = --strict-markers --disable-warnings --cov=src --cov=presets --cov=evaluation --cov-report=term-missing --cov-report=xml
 testpaths = tests
 pythonpath = src
 markers =


### PR DESCRIPTION
This PR removes the unrecognized `--timeout` argument from `pytest.ini`, which caused CI failures. By deleting the unsupported option, tests should run with default timeout settings and stabilize the CI workflow.